### PR TITLE
Setup Inertia Vue plugin

### DIFF
--- a/src/inertiajs-stubs/resources/js/Shared/Layout.vue
+++ b/src/inertiajs-stubs/resources/js/Shared/Layout.vue
@@ -19,7 +19,7 @@
                 <inertia-link class="nav-link" href="/contact">Contact</inertia-link>
               </li>
             </ul>
-          
+
           </div>
         </div>
       </nav>
@@ -37,13 +37,3 @@
     </main>
   </div>
 </template>
-
-<script>
-import { InertiaLink } from 'inertia-vue'
-
-export default {
-  components: {
-    InertiaLink,
-  },
-}
-</script>

--- a/src/inertiajs-stubs/resources/js/app.js
+++ b/src/inertiajs-stubs/resources/js/app.js
@@ -3,6 +3,8 @@ require('./bootstrap')
 import Inertia from 'inertia-vue'
 import Vue from 'vue'
 
+Vue.use(Inertia)
+
 let app = document.getElementById('app')
 
 new Vue({

--- a/src/inertiajs-stubs/resources/js/app.js
+++ b/src/inertiajs-stubs/resources/js/app.js
@@ -9,8 +9,8 @@ new Vue({
   render: h => h(Inertia, {
     props: {
       initialPage: JSON.parse(app.dataset.page),
-      resolveComponent: (component) => {
-        return import(`@/Pages/${component}`).then(module => module.default)
+      resolveComponent: (name) => {
+        return import(`@/Pages/${name}`).then(module => module.default)
       },
     },
   }),


### PR DESCRIPTION
I've created a plugin for the Inertia-Vue adapter which auto registers the `<inertia-link>` component, as well as makes `this.$inertia` available as a component property. It also adds some new [remember local state functionality](https://github.com/inertiajs/inertia-vue#remembering-local-component-state).

This PR brings the preset up-to-date.