### PR TITLE
Update the frontend preset for InertiaJS 0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "laravel/framework": "^5.8",
-    "inertiajs/inertia-laravel": "dev-master"
+    "inertiajs/inertia-laravel": "^0.1"
   },
   "require-dev": {
     "orchestra/testbench": "^3.8"

--- a/src/InertiaJsPreset.php
+++ b/src/InertiaJsPreset.php
@@ -23,8 +23,8 @@ class InertiaJsPreset extends Preset
     {
         return array_merge([
             '@babel/plugin-syntax-dynamic-import' => '^7.2.0',
-            '@inertiajs/inertia' => '^0.1',
-            '@inertiajs/inertia-vue' => '^0.1',
+            '@inertiajs/inertia' => '^0.1.0',
+            '@inertiajs/inertia-vue' => '^0.1.0',
             'vue-template-compiler' => '^2.6.10',
         ], $packages);
     }

--- a/src/InertiaJsPreset.php
+++ b/src/InertiaJsPreset.php
@@ -31,7 +31,6 @@ class InertiaJsPreset extends Preset
 
     protected static function updateBootstrapping()
     {
-        copy(__DIR__.'/inertiajs-stubs/.babelrc', base_path('.babelrc'));
         copy(__DIR__.'/inertiajs-stubs/webpack.mix.js', base_path('webpack.mix.js'));
 
         copy(__DIR__.'/inertiajs-stubs/resources/js/app.js', resource_path('js/app.js'));

--- a/src/InertiaJsPreset.php
+++ b/src/InertiaJsPreset.php
@@ -23,8 +23,8 @@ class InertiaJsPreset extends Preset
     {
         return array_merge([
             '@babel/plugin-syntax-dynamic-import' => '^7.2.0',
-            'inertia' => 'github:inertiajs/inertia',
-            'inertia-vue' => 'inertiajs/inertia-vue',
+            '@inertiajs/inertia' => '^0.1',
+            '@inertiajs/inertia-vue' => '^0.1',
             'vue-template-compiler' => '^2.6.10',
         ], $packages);
     }
@@ -32,7 +32,6 @@ class InertiaJsPreset extends Preset
     protected static function updateBootstrapping()
     {
         copy(__DIR__.'/inertiajs-stubs/.babelrc', base_path('.babelrc'));
-
         copy(__DIR__.'/inertiajs-stubs/webpack.mix.js', base_path('webpack.mix.js'));
 
         copy(__DIR__.'/inertiajs-stubs/resources/js/app.js', resource_path('js/app.js'));

--- a/src/inertiajs-stubs/.babelrc
+++ b/src/inertiajs-stubs/.babelrc
@@ -1,3 +1,0 @@
-{
-  "plugins": ["@babel/plugin-syntax-dynamic-import"]
-}

--- a/src/inertiajs-stubs/resources/js/app.js
+++ b/src/inertiajs-stubs/resources/js/app.js
@@ -1,14 +1,14 @@
 require('./bootstrap')
 
-import Inertia from 'inertia-vue'
+import { InertiaApp } from '@inertiajs/inertia-vue'
 import Vue from 'vue'
 
-Vue.use(Inertia)
+Vue.use(InertiaApp)
 
 let app = document.getElementById('app')
 
 new Vue({
-  render: h => h(Inertia, {
+  render: h => h(InertiaApp, {
     props: {
       initialPage: JSON.parse(app.dataset.page),
       resolveComponent: (name) => {

--- a/src/inertiajs-stubs/webpack.mix.js
+++ b/src/inertiajs-stubs/webpack.mix.js
@@ -3,7 +3,8 @@ const path = require('path')
 
 mix.js('resources/js/app.js', 'public/js')
    .sass('resources/sass/app.scss', 'public/css')
-     output: { chunkFilename: 'js/[name].[contenthash].js' },
+   .webpackConfig({
+     output: { chunkFilename: 'js/[name].js?id=[chunkhash]' },
      resolve: {
        alias: {
          'vue$': 'vue/dist/vue.runtime.js',

--- a/src/inertiajs-stubs/webpack.mix.js
+++ b/src/inertiajs-stubs/webpack.mix.js
@@ -7,7 +7,7 @@ mix.js('resources/js/app.js', 'public/js')
      output: { chunkFilename: 'js/[name].js?id=[chunkhash]' },
      resolve: {
        alias: {
-         'vue$': 'vue/dist/vue.runtime.js',
+         'vue$': 'vue/dist/vue.runtime.esm.js',
          '@': path.resolve('resources/js'),
        },
      },

--- a/src/inertiajs-stubs/webpack.mix.js
+++ b/src/inertiajs-stubs/webpack.mix.js
@@ -1,8 +1,8 @@
 const mix = require('laravel-mix')
 const path = require('path')
 
-mix.sass('resources/sass/app.scss', 'public/css')
-   .js('resources/js/app.js', 'public/js').webpackConfig({
+mix.js('resources/js/app.js', 'public/js')
+   .sass('resources/sass/app.scss', 'public/css')
      output: { chunkFilename: 'js/[name].[contenthash].js' },
      resolve: {
        alias: {

--- a/src/inertiajs-stubs/webpack.mix.js
+++ b/src/inertiajs-stubs/webpack.mix.js
@@ -11,3 +11,6 @@ mix.sass('resources/sass/app.scss', 'public/css')
        },
      },
    })
+   .babelConfig({
+       plugins: ['@babel/plugin-syntax-dynamic-import']
+   })


### PR DESCRIPTION
With [today's release](https://twitter.com/reinink/status/1161356374468640768) of the first release (0.1) of InertiaJS, I've updated the version constraints of this preset to match.

* The views themselves haven't changed
* I've moved the babel configuration out of `.babelrc` to the `babelConfig` method in the `webpack.mix.js` file
* Imports of `Inertia` have been replaced by the the named export (`InertiaApp`)
* Filename chunking has been updated to store the chunkhash in the query string, per inertiajs/inertia-vue#41

I think that is pretty much everything, but let me know if anything has been missed!