### PR TITLE
Copy stubbed HTTP Kernel to add Inertia middleware

### DIFF
--- a/src/InertiaJsPreset.php
+++ b/src/InertiaJsPreset.php
@@ -14,6 +14,7 @@ class InertiaJsPreset extends Preset
         static::updateBootstrapping();
         static::updateWelcomePage();
         static::updateGitignore();
+        static::updateKernel();
         static::scaffoldComponents();
         static::scaffoldRoutes();
         static::removeNodeModules();
@@ -53,6 +54,11 @@ class InertiaJsPreset extends Preset
             file_get_contents(__DIR__.'/inertiajs-stubs/gitignore'),
             FILE_APPEND
         );
+    }
+
+    protected static function updateKernel()
+    {
+        copy(__DIR__.'/inertiajs-stubs/app/Http/Kernel.php', app_path('Http/Kernel.php'));
     }
 
     protected static function scaffoldComponents()

--- a/src/inertiajs-stubs/app/Http/Kernel.php
+++ b/src/inertiajs-stubs/app/Http/Kernel.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    /**
+     * The application's global HTTP middleware stack.
+     *
+     * These middleware are run during every request to your application.
+     *
+     * @var array
+     */
+    protected $middleware = [
+        \App\Http\Middleware\TrustProxies::class,
+        \App\Http\Middleware\CheckForMaintenanceMode::class,
+        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
+        \App\Http\Middleware\TrimStrings::class,
+        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+    ];
+
+    /**
+     * The application's route middleware groups.
+     *
+     * @var array
+     */
+    protected $middlewareGroups = [
+        'web' => [
+            \App\Http\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+            // \Illuminate\Session\Middleware\AuthenticateSession::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \App\Http\Middleware\VerifyCsrfToken::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \Inertia\Middleware::class,
+        ],
+
+        'api' => [
+            'throttle:60,1',
+            'bindings',
+        ],
+    ];
+
+    /**
+     * The application's route middleware.
+     *
+     * These middleware may be assigned to groups or used individually.
+     *
+     * @var array
+     */
+    protected $routeMiddleware = [
+        'auth' => \App\Http\Middleware\Authenticate::class,
+        'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
+        'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
+        'can' => \Illuminate\Auth\Middleware\Authorize::class,
+        'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
+        'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
+        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+    ];
+
+    /**
+     * The priority-sorted list of middleware.
+     *
+     * This forces non-global middleware to always be in the given order.
+     *
+     * @var array
+     */
+    protected $middlewarePriority = [
+        \Illuminate\Session\Middleware\StartSession::class,
+        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+        \App\Http\Middleware\Authenticate::class,
+        \Illuminate\Session\Middleware\AuthenticateSession::class,
+        \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        \Illuminate\Auth\Middleware\Authorize::class,
+    ];
+}


### PR DESCRIPTION
I ran into an issue with the preset where delete requests don't work correctly with a redirect, as described in the upcoming docs.

If we're going to kickstart development using Inertia with the preset, it should be as ready-to-go as possible.

I'm not sure if there's a better way to update `app/Http/Kernel.php` than this, as it would mean having to keep the file up to date. Open to suggestions.