### PR TITLE
Update for Laravel 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This preset scaffolding removes the manual steps required to get up and running 
 
 ## Usage
 
-1. Fresh install Laravel >= 5.8 and cd to your app.
+1. Fresh install Laravel >= 6.0 and cd to your app.
 2. Install this preset via `composer require laravel-frontend-presets/inertiajs`. Laravel will automatically discover this package. No need to register the service provider.
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This preset scaffolding removes the manual steps required to get up and running 
 ## Usage
 
 1. Fresh install Laravel >= 6.0 and cd to your app.
-2. Install this preset via `composer require laravel-frontend-presets/inertiajs`. Laravel will automatically discover this package. No need to register the service provider.
+2. Install this preset via `composer require --dev laravel-frontend-presets/inertiajs`. Laravel will automatically discover this package. No need to register the service provider.
 
 ### Installation
 

--- a/src/InertiaJsPreset.php
+++ b/src/InertiaJsPreset.php
@@ -109,7 +109,7 @@ class InertiaJsPreset extends Preset
         );
     }
 
-    public static function publishServiceProvider()
+    public static function publishInertiaServiceProvider()
     {
         copy(
             __DIR__.'/inertiajs-stubs/providers/InertiaJsServiceProvider.stub',

--- a/src/InertiaJsPreset.php
+++ b/src/InertiaJsPreset.php
@@ -12,12 +12,8 @@ use Symfony\Component\Process\Process;
 
 class InertiaJsPreset extends Preset
 {
-    private static $command;
-
-    public static function install($command)
+    public static function install()
     {
-        static::$command = $command;
-
         static::updatePackages();
         static::updateBootstrapping();
         static::updateComposer(false);

--- a/src/InertiaJsPreset.php
+++ b/src/InertiaJsPreset.php
@@ -17,7 +17,6 @@ class InertiaJsPreset extends Preset
         static::$command = $command;
 
         static::updatePackages();
-        static::installBootstrapDefault();
         static::updateComposer(false);
         static::updateBootstrapping();
         static::updateWelcomePage();
@@ -85,23 +84,6 @@ class InertiaJsPreset extends Preset
     protected static function scaffoldRoutes()
     {
         copy(__DIR__.'/inertiajs-stubs/routes/web.php', base_path('routes/web.php'));
-    }
-
-    protected static function installBootstrapDefault()
-    {
-        if (! file_exists(base_path('composer.json'))) {
-            return;
-        }
-
-        tap(new Process('composer require --dev laravel/ui=^1.0', base_path()), function ($process) {
-            $process->run();
-
-            Artisan::call('preset bootstrap', [], static::$command->getOutput());
-        });
-
-        tap(new Process('composer remove --dev laravel/ui', base_path()), function ($process) {
-            $process->run();
-        });
     }
 
     protected static function updateComposer($dev = true)

--- a/src/InertiaJsPreset.php
+++ b/src/InertiaJsPreset.php
@@ -2,11 +2,13 @@
 
 namespace LaravelFrontendPresets\InertiaJsPreset;
 
-use Illuminate\Support\Arr;
+use Illuminate\Container\Container;
 use Illuminate\Filesystem\Filesystem;
-use Symfony\Component\Process\Process;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Foundation\Console\Presets\Preset;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Symfony\Component\Process\Process;
 
 class InertiaJsPreset extends Preset
 {

--- a/src/InertiaJsPreset.php
+++ b/src/InertiaJsPreset.php
@@ -18,6 +18,7 @@ class InertiaJsPreset extends Preset
 
         static::updatePackages();
         static::installBootstrapDefault();
+        static::updateComposer(false);
         static::updateBootstrapping();
         static::updateWelcomePage();
         static::updateGitignore();
@@ -34,6 +35,13 @@ class InertiaJsPreset extends Preset
             '@inertiajs/inertia-vue' => '^0.1.0',
             'vue' => '^2.5.17',
             'vue-template-compiler' => '^2.6.10',
+        ], $packages);
+    }
+
+    protected static function updateComposerArray(array $packages)
+    {
+        return array_merge([
+            'inertiajs/inertia-laravel' => '^0.1',
         ], $packages);
     }
 
@@ -94,5 +102,28 @@ class InertiaJsPreset extends Preset
         tap(new Process('composer remove --dev laravel/ui', base_path()), function ($process) {
             $process->run();
         });
+    }
+
+    protected static function updateComposer($dev = true)
+    {
+        if (! file_exists(base_path('composer.json'))) {
+            return;
+        }
+
+        $configurationKey = $dev ? 'require-dev' : 'require';
+
+        $packages = json_decode(file_get_contents(base_path('composer.json')), true);
+
+        $packages[$configurationKey] = static::updateComposerArray(
+            array_key_exists($configurationKey, $packages) ? $packages[$configurationKey] : [],
+            $configurationKey
+        );
+
+        ksort($packages[$configurationKey]);
+
+        file_put_contents(
+            base_path('composer.json'),
+            json_encode($packages, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT).PHP_EOL
+        );
     }
 }

--- a/src/InertiaJsPresetServiceProvider.php
+++ b/src/InertiaJsPresetServiceProvider.php
@@ -10,7 +10,7 @@ class InertiaJsPresetServiceProvider extends ServiceProvider
     public function boot()
     {
         PresetCommand::macro('inertiajs', function ($command) {
-            InertiaJsPreset::install($command);
+            InertiaJsPreset::install();
 
             $command->info('Inertia.js scaffolding installed successfully.');
             $command->info('Please run "npm install && npm run dev" to compile your fresh scaffolding.');

--- a/src/InertiaJsPresetServiceProvider.php
+++ b/src/InertiaJsPresetServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace LaravelFrontendPresets\InertiaJsPreset;
 
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\Console\PresetCommand;
+use Illuminate\Support\ServiceProvider;
 
 class InertiaJsPresetServiceProvider extends ServiceProvider
 {

--- a/src/InertiaJsPresetServiceProvider.php
+++ b/src/InertiaJsPresetServiceProvider.php
@@ -10,7 +10,7 @@ class InertiaJsPresetServiceProvider extends ServiceProvider
     public function boot()
     {
         PresetCommand::macro('inertiajs', function ($command) {
-            InertiaJsPreset::install();
+            InertiaJsPreset::install($command);
 
             $command->info('Inertia.js scaffolding installed successfully.');
             $command->info('Please run "npm install && npm run dev" to compile your fresh scaffolding.');

--- a/src/inertiajs-stubs/gitignore
+++ b/src/inertiajs-stubs/gitignore
@@ -1,2 +1,3 @@
 /public/css
 /public/js
+/public/mix-manifest.json

--- a/src/inertiajs-stubs/providers/InertiaJsServiceProvider.stub
+++ b/src/inertiajs-stubs/providers/InertiaJsServiceProvider.stub
@@ -11,11 +11,6 @@ class InertiaJsServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $this->registerInertia();
-    }
-
-    protected function registerInertia()
-    {
         Inertia::version(function () {
             return md5_file(public_path('mix-manifest.json'));
         });

--- a/src/inertiajs-stubs/providers/InertiaJsServiceProvider.stub
+++ b/src/inertiajs-stubs/providers/InertiaJsServiceProvider.stub
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\ServiceProvider;
+use Inertia\Inertia;
+
+class InertiaJsServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->registerInertia();
+    }
+
+    protected function registerInertia()
+    {
+        Inertia::version(function () {
+            return md5_file(public_path('mix-manifest.json'));
+        });
+
+        Inertia::share([
+            'auth' => function () {
+                return [
+                    'user' => Auth::user() ? [
+                        'id' => Auth::user()->id,
+                        'name' => Auth::user()->name,
+                        'email' => Auth::user()->email,
+                        'avatar' => Auth::user()->avatar(),
+                    ] : null,
+                ];
+            },
+            'flash' => function () {
+                return [
+                    'success' => Session::get('success'),
+                ];
+            },
+            'errors' => function () {
+                return Session::get('errors')
+                    ? Session::get('errors')->getBag('default')->getMessages()
+                    : (object) [];
+            },
+        ]);
+    }
+}

--- a/src/inertiajs-stubs/resources/js/Pages/About.vue
+++ b/src/inertiajs-stubs/resources/js/Pages/About.vue
@@ -1,6 +1,6 @@
 <template>
   <layout>
-    <h1>About</h1>
+    <h1 class="text-2xl font-semibold mb-3">About</h1>
     <p>About my first Inertia.js app!</p>
   </layout>
 </template>

--- a/src/inertiajs-stubs/resources/js/Pages/Contact.vue
+++ b/src/inertiajs-stubs/resources/js/Pages/Contact.vue
@@ -1,6 +1,6 @@
 <template>
   <layout>
-    <h1>Contact</h1>
+    <h1 class="text-2xl font-semibold mb-3">Contact</h1>
     <p>Contact me about my first Inertia.js app!</p>
   </layout>
 </template>

--- a/src/inertiajs-stubs/resources/js/Pages/Welcome.vue
+++ b/src/inertiajs-stubs/resources/js/Pages/Welcome.vue
@@ -1,6 +1,6 @@
 <template>
   <layout>
-    <h1>Welcome</h1>
+    <h1 class="text-2xl font-semibold mb-3">Welcome</h1>
     <p>Welcome to my first Inertia.js app!</p>
   </layout>
 </template>

--- a/src/inertiajs-stubs/resources/js/Shared/Layout.vue
+++ b/src/inertiajs-stubs/resources/js/Shared/Layout.vue
@@ -1,39 +1,23 @@
 <template>
-  <div>
-    <header>
-      <nav class="navbar navbar-expand-md navbar-light navbar-laravel">
-        <div class="container">
-          <inertia-link class="navbar-brand" href="/">Inertia.js</inertia-link>
+    <div>
+        <navbar />
 
-          <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-          </button>
-
-          <div class="collapse navbar-collapse" id="mainNav">
-
-            <ul class="navbar-nav mr-auto">
-              <li class="nav-item">
-                <inertia-link class="nav-link" href="/about">About</inertia-link>
-              </li>
-              <li class="nav-item">
-                <inertia-link class="nav-link" href="/contact">Contact</inertia-link>
-              </li>
-            </ul>
-
-          </div>
-        </div>
-      </nav>
-    </header>
-    <main class="py-4">
-      <div class="container">
-        <div class="row">
-          <div class="col">
-            <article>
-              <slot />
-            </article>
-          </div>
-        </div>
-      </div>
-    </main>
-  </div>
+        <main>
+            <div class="w-full max-w-6xl mx-auto p-4">
+                <article>
+                    <slot />
+                </article>
+            </div>
+        </main>
+    </div>
 </template>
+
+<script>
+import Navbar from '@/Shared/Navbar'
+
+export default {
+     components: {
+         Navbar,
+     }
+}
+</script>

--- a/src/inertiajs-stubs/resources/js/Shared/Navbar.vue
+++ b/src/inertiajs-stubs/resources/js/Shared/Navbar.vue
@@ -1,0 +1,35 @@
+<template>
+    <header class="bg-white shadow">
+        <div class="w-full max-w-6xl mx-auto sm:flex sm:justify-between sm:items-center sm:px-4 sm:py-3">
+            <div class="flex justify-between items-center px-4 py-3 sm:p-0">
+                <div>
+                    <inertia-link class="navbar-brand" href="/">Inertia.js</inertia-link>
+                </div>
+
+                <div class="sm:hidden">
+                    <button @click="isOpen = !isOpen" type="button" class="block text-gray-700 hover:text-gray-600 focus:text-gray-600 focus:outline-none">
+                        <svg class="h-6 w-6 fill-current" viewBox="0 0 24 24">
+                            <path v-if="isOpen" fill-rule="evenodd" d="M18.278 16.864a1 1 0 0 1-1.414 1.414l-4.829-4.828-4.828 4.828a1 1 0 0 1-1.414-1.414l4.828-4.829-4.828-4.828a1 1 0 0 1 1.414-1.414l4.829 4.828 4.828-4.828a1 1 0 1 1 1.414 1.414l-4.828 4.829 4.828 4.828z"/>
+                            <path v-if="!isOpen" fill-rule="evenodd" d="M4 5h16a1 1 0 0 1 0 2H4a1 1 0 1 1 0-2zm0 6h16a1 1 0 0 1 0 2H4a1 1 0 0 1 0-2zm0 6h16a1 1 0 0 1 0 2H4a1 1 0 0 1 0-2z"/>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+
+            <nav :class="isOpen ? 'block' : 'hidden'" class="px-2 pb-4 sm:flex sm:p-0">
+                <inertia-link class="block px-2 py-1 text-gray-700 font-semibold rounded hover:bg-gray-100 focus:bg-gray-100 focus:outline-none" href="/about">About</inertia-link>
+                <inertia-link class="mt-1 block px-2 py-1 text-gray-700 font-semibold rounded hover:bg-gray-100 focus:bg-gray-100 focus:outline-none sm:mt-0 sm:ml-2" href="/contact">Contact</inertia-link>
+            </nav>
+        </div>
+    </header>
+</template>
+
+<script>
+export default {
+    data() { 
+        return {
+            isOpen: false,
+        }
+    }
+}
+</script>

--- a/src/inertiajs-stubs/resources/sass/app.scss
+++ b/src/inertiajs-stubs/resources/sass/app.scss
@@ -1,15 +1,9 @@
 
+// Tailwind
+@import url('https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css');
+
 // Fonts
 @import url('https://fonts.googleapis.com/css?family=Nunito');
 
 // Variables
-@import 'variables';
 @import 'nprogress';
-
-// Bootstrap
-@import '~bootstrap/scss/bootstrap';
-
-.navbar-laravel {
-  background-color: #fff;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.04);
-}


### PR DESCRIPTION
We need to account for the fact that the default Bootstrap preset has been extracted to a separate package in laravel/ui and install this, before being able to run the Inertia.js preset over the top of it.