### PR TITLE
Fix naming call of publishInertiaServiceProvider()

### DIFF
--- a/src/InertiaJsPreset.php
+++ b/src/InertiaJsPreset.php
@@ -17,7 +17,7 @@ class InertiaJsPreset extends Preset
         static::updatePackages();
         static::updateBootstrapping();
         static::updateComposer(false);
-        static::publishServiceProvider();
+        static::publishInertiaServiceProvider();
         static::registerInertiaServiceProvider();
         static::updateWelcomePage();
         static::updateGitignore();


### PR DESCRIPTION
It looks like in 35ead4975b3d75cdb8a4f01be7409d693adf4b33 (part of #9), the `publishInertiaServiceProvider()` method was renamed but the call to it was left as `publishServiceProvider()`. This fixes the method call.