### PR TITLE
Remove avatar field

### DIFF
--- a/src/inertiajs-stubs/providers/InertiaJsServiceProvider.stub
+++ b/src/inertiajs-stubs/providers/InertiaJsServiceProvider.stub
@@ -22,7 +22,6 @@ class InertiaJsServiceProvider extends ServiceProvider
                         'id' => Auth::user()->id,
                         'name' => Auth::user()->name,
                         'email' => Auth::user()->email,
-                        'avatar' => Auth::user()->avatar(),
                     ] : null,
                 ];
             },


### PR DESCRIPTION
On a fresh version of laravel 6.0 Logging in without adding an additional avatar field in the DB and method on the model. This throws a fata error