### PR TITLE
add missing version webpack.mix.js

### DIFF
--- a/src/inertiajs-stubs/webpack.mix.js
+++ b/src/inertiajs-stubs/webpack.mix.js
@@ -15,3 +15,4 @@ mix.js('resources/js/app.js', 'public/js')
    .babelConfig({
        plugins: ['@babel/plugin-syntax-dynamic-import']
    })
+   .version()


### PR DESCRIPTION
I think it's missing `.version()` for the `webpack.mix.js` configuration.

In the `InertiaJsServiceProvider` it's using `md5_file(public_path('mix-manifest.json'))` to get the `md5` of the file, however without configuring the version the file will not change(the content will be the same).